### PR TITLE
change checkout to clone in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Note that these instructions are written so that (hopefully) a non-programmer ca
 Install [git](https://git-scm.com/) and a C++ compiler. (Note that the compiler must support C++17.) Then, install [CMake](https://cmake.org/).  
 (Optional) If you want to run the tests, install [Catch2](https://github.com/catchorg/Catch2/).
 ### Building
-Open a terminal, and checkout this repo:
+Open a terminal, and clone this repo:
 ```
-git checkout https://github.com/virchau13/pcse
+git clone https://github.com/virchau13/pcse
 ```
 Then run these commands:
 ```


### PR DESCRIPTION
The README directed the user to git checkout instead of clone. This fixes that.