### PR TITLE
Format CMakeLists.txt and isValidStmtStart refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,25 +1,29 @@
 project(pcse CXX)
 if(CMAKE_BUILD_TYPE STREQUAL "Release")
-	if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-		add_link_options(-lstdc++ -static-libgcc -static-libstdc++)
-	else()
-		add_link_options(-static)
-	endif()
+    if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+        add_link_options(-lstdc++ -static-libgcc -static-libstdc++)
+    else()
+        add_link_options(-static)
+    endif()
 endif()
 cmake_minimum_required(VERSION 3.10.3)
 set(CMAKE_CXX_STANDARD 17)
 
 if(MSVC)
-	add_compile_options(/W4 /WX)
+    add_compile_options(/W4 /WX)
 else()
-	add_compile_options(-Wall -Wextra -Wpedantic -Wno-class-memaccess -Werror=return-type)
+    add_compile_options(-Wall -Wextra -Wpedantic -Wno-class-memaccess
+                        -Werror=return-type)
 endif()
 
 # tests
 find_package(Catch2)
 if(Catch2_FOUND)
-	add_executable(tests EXCLUDE_FROM_ALL test/tests-main.cpp test/lexer.test.cpp test/utils.test.cpp test/fraction.test.cpp test/parser.test.cpp test/interpreter.test.cpp)
-	target_link_libraries(tests Catch2::Catch2)
+    add_executable(
+        tests EXCLUDE_FROM_ALL
+        test/tests-main.cpp test/lexer.test.cpp test/utils.test.cpp
+        test/fraction.test.cpp test/parser.test.cpp test/interpreter.test.cpp)
+    target_link_libraries(tests Catch2::Catch2)
 endif()
 
 # main

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -570,10 +570,9 @@ const std::vector<TokenType> valid_stmt_starts = {
 };
 
 inline bool isValidStmtStart(const TokenType type) noexcept {
-	for(const auto t : valid_stmt_starts){
-		if(t == type) return true;
-	} 
-	return false;
+    return std::any_of(valid_stmt_starts.begin(), valid_stmt_starts.end(), [type](const TokenType& t) {
+                return t == type;
+            });
 }
 
 class Block {


### PR DESCRIPTION
- Format CMakeLists.txt to make it more readable.
- Refactor isValidStmtStart to use std::any_of algorithm instead of raw loop.