### PR TITLE
docs: add missing ebnf alternation symbol

### DIFF
--- a/docs/grammar.ebnf
+++ b/docs/grammar.ebnf
@@ -7,7 +7,7 @@ block = { stmt };
 
 topstmt = stmt | 
 		DECLARE, identifier, COLON, type |
-		CONSTANT, identifier, =, expr
+		CONSTANT, identifier, =, expr |
 		PROCEDURE, identifier, [ LEFT_PAR, paramlist, RIGHT_PAR ], block, ENDPROCEDURE |
 		FUNCTION, identifier [ LEFT_PAR, paramlist, RIGHT_PAR ], RETURNS, type, block, ENDFUNCTION
 ;


### PR DESCRIPTION
The previous documentation implied that a PROCEDURE followed an expression when declaring constants. This is incorrect, since the PROCEDURE itself is intended to be a statement.

Signed-off-by: Lucas Sta Maria <lucas@priime.dev>